### PR TITLE
[codex] Document forecast CSV schema

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,14 +14,40 @@ I previously collected `overview_week`, but it is not published here because tha
 
 ## Detailed Forecasts (`forecast`)
 
-Detailed forecast JSON files are grouped by month and converted to CSV. Each ZIP contains CSV files for all regions in the month.
+Detailed forecast JSON files are grouped by month and converted to CSV. Each ZIP contains CSV files for all regions in the month. This is a history of forecasts as they were issued in the past, not later-confirmed observed weather.
 
 - Location: `forecast/forecast_YYYYMM.zip`
 - File name inside each ZIP: `forecast_YYYYMM_{region_code}.csv`
 - Source: `https://www.jma.go.jp/bosai/forecast/data/forecast/{region_code}.json`
 - Period: from `2021-11-04`
 - Collection interval: around 3 times per day
-- Notes: Some dates or regions may be missing. If correction reports are issued in addition to regular reports, a day may have 4 or more records.
+- Update timing: one month of data is zipped and normally uploaded at the beginning of the following month.
+- Notes: There are no known missing periods, but unknown collection gaps may exist. If correction reports are issued in addition to regular reports, a day may have 4 or more records.
+
+CSV columns for ordinary region codes:
+
+- `publishingOffice`: issuing office name
+- `reportDatetime`: report issue time
+- `timeDefine`: forecast target datetime
+- `areaName`: target area name
+- `areaCode`: target area code
+- `weatherCodes`: weather code. See `weatherCode.csv` / `weatherCodes.json`.
+- `weathers`: forecast weather text
+- `winds`: forecast wind text
+- `waves`: forecast wave text
+- `pops`: probability of precipitation
+- `temps`: temperature
+- `tempsMin`: minimum temperature
+- `tempsMax`: maximum temperature
+- `tempsMinUpper`: upper bound of the minimum temperature forecast range
+- `tempsMaxUpper`: upper bound of the maximum temperature forecast range
+- `tempsMinLower`: lower bound of the minimum temperature forecast range
+- `tempsMaxLower`: lower bound of the maximum temperature forecast range
+- `reliabilities`: reliability class
+
+The national forecast file, `forecast_YYYYMM_010000.csv`, additionally has `regionName` and `regionCode`, and its forecast target datetime column is named `time`. Rows are emitted from the source JSON time series, so some fields are blank depending on the target time and area.
+
+`reportDatetime` is the time when the forecast was issued. `timeDefine` or `time` is the datetime targeted by the forecast. For example, a forecast issued at 05:00 on May 1 may contain a row targeting 00:00 on May 2.
 
 Region codes:
 
@@ -40,14 +66,44 @@ Region codes:
 
 ## Overview Forecasts (`overview_forecast`)
 
-Overview forecast JSON files are grouped by month and converted to CSV. Each ZIP contains CSV files for all regions in the month.
+Overview forecast JSON files are grouped by month and converted to CSV. Each ZIP contains CSV files for all regions in the month. This is a history of forecast text as it was issued in the past, not later-confirmed observed weather.
 
 - Location: `overview_forecast/overview_forecast_YYYYMM.zip`
 - File name inside each ZIP: `overview_forecast_YYYYMM_{region_code}.csv`
 - Source: `https://www.jma.go.jp/bosai/forecast/data/overview_forecast/{region_code}.json`
 - Period: from `2021-12-15`
 - Collection interval: around 3 times per day
+- Update timing: one month of data is zipped and normally uploaded at the beginning of the following month.
+- Notes: There are no known missing periods, but unknown collection gaps may exist.
 - Region codes: same as the detailed forecasts, except `010000` is not included.
+
+CSV columns:
+
+- `publishingOffice`: issuing office name
+- `reportDatetime`: report issue time
+- `targetArea`: target area
+- `headlineText`: headline text
+- `text`: overview forecast body. Line breaks in the source JSON are replaced with spaces.
+
+`reportDatetime` is the time when the overview forecast was issued. The target dates and times of the overview forecast are not stored in separate datetime columns; they are included as prose in `headlineText` or `text`.
+
+## Weather Code Tables
+
+The following two files provide lookup tables for `weatherCodes` in `forecast`.
+
+- `weatherCode.csv`: weather code table in CSV format
+- `weatherCodes.json`: weather code table in JSON format
+
+Columns in `weatherCode.csv`:
+
+- `weatherCode`: weather code
+- `weatherPictDay`: daytime weather icon file name
+- `weatherPictNight`: nighttime weather icon file name
+- `Group`: weather category group
+- `weatherJ`: Japanese weather name
+- `weatherE`: English weather name
+
+`weatherCodes.json` is a JSON object keyed by `weatherCode`. Each value is an array in the order `weatherPictDay`, `weatherPictNight`, `Group`, `weatherJ`, and `weatherE`.
 
 ## Warnings and Advisories (`warning`)
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,40 @@
 
 ## 詳細天気予報 (`forecast`)
 
-地域ごとの詳細天気予報 JSON を月単位にまとめ、CSV 化したものです。全地域・1か月分の CSV を ZIP 圧縮しています。
+地域ごとの詳細天気予報 JSON を月単位にまとめ、CSV 化したものです。全地域・1か月分の CSV を ZIP 圧縮しています。これは過去に発表された予報の履歴であり、後から確定した実際の天気ではありません。
 
 - 格納場所: `forecast/forecast_YYYYMM.zip`
 - ZIP 内ファイル名: `forecast_YYYYMM_{地域コード}.csv`
 - 収集元: `https://www.jma.go.jp/bosai/forecast/data/forecast/{region_code}.json`
 - 期間: `2021-11-04` 以降
 - 収集間隔: 1日3回前後
-- 備考: 一部の日・地域に取得漏れがあります。定時発表に加えて訂正報があった場合、1日4回以上になることがあります。
+- 更新: 1か月分を ZIP 化し、原則として翌月初にアップロードします。
+- 備考: 既知の欠測期間はありませんが、未知の取得漏れが含まれる可能性があります。定時発表に加えて訂正報があった場合、1日4回以上になることがあります。
+
+通常の地域コードの CSV 列:
+
+- `publishingOffice`: 発表官署名
+- `reportDatetime`: 発表時刻
+- `timeDefine`: 予報対象日時
+- `areaName`: 対象区域名
+- `areaCode`: 対象区域コード
+- `weatherCodes`: 天気コード。対応表は `weatherCode.csv` / `weatherCodes.json` を参照してください。
+- `weathers`: 天気の予報文
+- `winds`: 風の予報文
+- `waves`: 波の予報文
+- `pops`: 降水確率
+- `temps`: 気温
+- `tempsMin`: 最低気温
+- `tempsMax`: 最高気温
+- `tempsMinUpper`: 最低気温の予測範囲上限
+- `tempsMaxUpper`: 最高気温の予測範囲上限
+- `tempsMinLower`: 最低気温の予測範囲下限
+- `tempsMaxLower`: 最高気温の予測範囲下限
+- `reliabilities`: 信頼度
+
+全国予報の `forecast_YYYYMM_010000.csv` は、上記に加えて `regionName` と `regionCode` を持ち、予報対象日時の列名が `time` です。各列は元 JSON の時系列ごとに出力しているため、対象時刻や対象区域によって空欄になる項目があります。
+
+`reportDatetime` は「その予報が発表された時刻」です。`timeDefine` または `time` は「予報の対象となる時刻」です。例えば、5月1日5時発表の予報の中に、5月2日0時を対象にした行が含まれることがあります。
 
 地域コード:
 
@@ -40,14 +66,44 @@
 
 ## 概要予報 (`overview_forecast`)
 
-地域ごとの概要予報 JSON を月単位にまとめ、CSV 化したものです。全地域・1か月分の CSV を ZIP 圧縮しています。
+地域ごとの概要予報 JSON を月単位にまとめ、CSV 化したものです。全地域・1か月分の CSV を ZIP 圧縮しています。これは過去に発表された予報文の履歴であり、後から確定した実際の天気ではありません。
 
 - 格納場所: `overview_forecast/overview_forecast_YYYYMM.zip`
 - ZIP 内ファイル名: `overview_forecast_YYYYMM_{地域コード}.csv`
 - 収集元: `https://www.jma.go.jp/bosai/forecast/data/overview_forecast/{region_code}.json`
 - 期間: `2021-12-15` 以降
 - 収集間隔: 1日3回前後
+- 更新: 1か月分を ZIP 化し、原則として翌月初にアップロードします。
+- 備考: 既知の欠測期間はありませんが、未知の取得漏れが含まれる可能性があります。
 - 地域コード: `010000` を除き、詳細天気予報と同じです。
+
+CSV 列:
+
+- `publishingOffice`: 発表官署名
+- `reportDatetime`: 発表時刻
+- `targetArea`: 対象地域
+- `headlineText`: 見出し文
+- `text`: 概要予報本文。元 JSON の改行はスペースに置換しています。
+
+`reportDatetime` は「その概要予報が発表された時刻」です。概要予報の対象日時は独立した日時列ではなく、`headlineText` や `text` の本文中に文章として含まれます。
+
+## 天気コード対応表
+
+`forecast` の `weatherCodes` を読み取るための対応表として、以下の2形式を置いています。
+
+- `weatherCode.csv`: CSV 形式の天気コード対応表
+- `weatherCodes.json`: JSON 形式の天気コード対応表
+
+`weatherCode.csv` の列:
+
+- `weatherCode`: 天気コード
+- `weatherPictDay`: 昼の天気アイコンファイル名
+- `weatherPictNight`: 夜の天気アイコンファイル名
+- `Group`: 天気分類グループ
+- `weatherJ`: 日本語の天気名
+- `weatherE`: 英語の天気名
+
+`weatherCodes.json` は `weatherCode` をキーにした JSON オブジェクトで、値は `weatherPictDay`、`weatherPictNight`、`Group`、`weatherJ`、`weatherE` の順の配列です。
 
 ## 警報・注意報 (`warning`)
 


### PR DESCRIPTION
## Summary
- Add CSV column descriptions for forecast and overview_forecast datasets
- Document weatherCode.csv and weatherCodes.json lookup files
- Clarify reportDatetime versus forecast target datetime and monthly ZIP upload timing
- State that forecast datasets are historical issued forecasts, not observed weather

## Validation
- Checked representative public ZIP headers for forecast and overview_forecast
- git diff --check